### PR TITLE
New evzen score by `Regenschori ČL`

### DIFF
--- a/_hall/1696094030458.json
+++ b/_hall/1696094030458.json
@@ -1,0 +1,1 @@
+{"nickname":"Regenschori ČL","score":406,"timestamp":"2023-09-30T17:13:50.458Z"}


### PR DESCRIPTION
New request to add results by Regenschori ČL and score `406`. 
| KEY | VALUE |
| ------ | ---------- |
| nickname | **Regenschori ČL** |
| score | `406` |
| timestamp | 2023-09-30T17:13:50.458Z |

Filename: 1696094030458.json

```json
{
  "nickname": "Regenschori ČL",
  "score": 406,
  "timestamp": "2023-09-30T17:13:50.458Z"
}
```