### PR TITLE
New evzen score by `Máří z Dohalic`

### DIFF
--- a/_hall/1700413100459.json
+++ b/_hall/1700413100459.json
@@ -1,0 +1,1 @@
+{"nickname":"Máří z Dohalic","score":899,"secret":"evzenforever","timestamp":"2023-11-19T16:58:20.459Z"}


### PR DESCRIPTION
New request to add results by Máří z Dohalic and score `899`. 
| KEY | VALUE |
| ------ | ---------- |
| nickname | **Máří z Dohalic** |
| score | `899` |
| timestamp | 2023-11-19T16:58:20.459Z |

Filename: 1700413100459.json

```json
{
  "nickname": "Máří z Dohalic",
  "score": 899,
  "secret": "evzenforever",
  "timestamp": "2023-11-19T16:58:20.459Z"
}
```